### PR TITLE
Fixed setup.py for package building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     license="BSD (3-clause)",
     url="https://github.com/NSLS-II-ISS/isstools",
     packages=setuptools.find_packages(),
-    package_data={'isstools': ['ui/*.ui']},
+    package_data={'isstools': ['dialogs/*.ui']},
     #install_requires=['netcdf4','pyparsing', 'pysmbc', 'pytable'], #needs zbarlight
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
There is a problem with the current package. We need to update setup.py.
Is this the best branch to place in?

(tested this locally by conda building -c lightsource2-tag meta.yaml
where meta.yaml pointed to my local isstools branch)