### PR TITLE
Added more info to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setuptools.setup(
     license="BSD (3-clause)",
     url="https://github.com/NSLS-II-ISS/isstools",
     packages=setuptools.find_packages(),
-    package_data={'isstools': ['dialogs/*.ui']},
+    # any non python files need to be declared here
+    package_data={'isstools': ['*.json', 'ui/*.ui', 'dialogs/*.ui']},
     #install_requires=['netcdf4','pyparsing', 'pysmbc', 'pytable'], #needs zbarlight
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
I needed some more additions for issgui to work on QAS.
works now, no need to merge just yet. Need to check with Eli first.
We'll probably want to check if he's reasonably happy and ask if it's fine to go ahead and tag to 1.3.1 (and update lightsource2 packages)