### PR TITLE
Fixed toolbar clearing for new matplotlib API

### DIFF
--- a/isstools/xview.py
+++ b/isstools/xview.py
@@ -165,6 +165,9 @@ class XviewGui(*uic.loadUiType(ui_path)):
     def close_app(self):
         self.close()
 
+    def reset_toolbar(self):
+
+
     def addCanvas(self):
         self.figureBinned = Figure()
         self.figureBinned.set_facecolor(color='#FcF9F6')
@@ -239,9 +242,7 @@ class XviewGui(*uic.loadUiType(ui_path)):
     def plotBinnedData(self):
         selected_items = (self.listFiles_bin.selectedItems())
         self.figureBinned.ax.clear()
-        self.toolbar._views.clear()
-        self.toolbar._positions.clear()
-        self.toolbar._update_view()
+        self.toolbar._nav_stack.clear()
         self.canvas.draw_idle()
 
         if self.listBinnedDataNumerator.currentRow() == -1 or self.listBinnedDataDenominator.currentRow() == -1:
@@ -748,9 +749,7 @@ class XviewGui(*uic.loadUiType(ui_path)):
 
     def reset_figure(self,axis,toolbar,canvas):
         axis.clear()
-        toolbar._views.clear()
-        toolbar._positions.clear()
-        toolbar._update_view()
+        self.toolbar._nav_stack.clear()
         canvas.draw_idle()
 
 


### PR DESCRIPTION
@elistavitski this seems to have done the trick.

can you test and make sure it works for you? I assume what was screwing up was the history wasn't cleared anymore