### PR TITLE
Use `qtpy`

### DIFF
--- a/isstools/batch/batch.py
+++ b/isstools/batch/batch.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import collections
 import numpy as np
-from PyQt5 import QtGui
+from qtpy import QtGui
 
 class BatchManager():
 

--- a/isstools/dialogs/BasicDialogs.py
+++ b/isstools/dialogs/BasicDialogs.py
@@ -1,4 +1,4 @@
-from PyQt5 import  QtWidgets
+from qtpy import  QtWidgets
 
 def message_box(title, message):
     messageBox = QtWidgets.QMessageBox()

--- a/isstools/dialogs/GetEmailAddress.py
+++ b/isstools/dialogs/GetEmailAddress.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/GetEmailAddress.ui')

--- a/isstools/dialogs/MoveMotorDialog.py
+++ b/isstools/dialogs/MoveMotorDialog.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/MoveMotorDialog.ui')

--- a/isstools/dialogs/PeriodicTable.py
+++ b/isstools/dialogs/PeriodicTable.py
@@ -1,13 +1,13 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem, QPushButton
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGridLayout, QPushButton, QLabel
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem, QPushButton
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QGridLayout, QPushButton, QLabel
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/PeriodicTable.ui')
 
-from PyQt5 import uic, QtGui, QtCore
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGridLayout, QLabel, QMainWindow
-from PyQt5.QtCore import pyqtSignal
+from qtpy import uic, QtGui, QtCore
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QGridLayout, QLabel, QMainWindow
+from qtpy.QtCore import Signal
 
 
 
@@ -76,7 +76,7 @@ class ElementLabel(QLabel):
 
 
 class PeriodicTableWidget(*uic.loadUiType(ui_path)):
-    element_selected = pyqtSignal(str)
+    element_selected = Signal(str)
 
     elements = {
         # Main table

--- a/isstools/dialogs/Prepare_BL_Dialog.py
+++ b/isstools/dialogs/Prepare_BL_Dialog.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore, QtWidgets
+from qtpy import uic, QtGui, QtCore, QtWidgets
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/Prepare_BL_Dialog.ui')

--- a/isstools/dialogs/SelectNNeffPointsDialog.py
+++ b/isstools/dialogs/SelectNNeffPointsDialog.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/SelectNNeffPointsDialog.ui')

--- a/isstools/dialogs/SetEnergy.py
+++ b/isstools/dialogs/SetEnergy.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/SetEnergy.ui')

--- a/isstools/dialogs/UpdateAngleOffset.py
+++ b/isstools/dialogs/UpdateAngleOffset.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/UpdateAngleOffset.ui')

--- a/isstools/dialogs/UpdateHHMFeedbackSettings.py
+++ b/isstools/dialogs/UpdateHHMFeedbackSettings.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/UpdateHHMFeedbackSettings.ui')

--- a/isstools/dialogs/UpdateMotorLimit.py
+++ b/isstools/dialogs/UpdateMotorLimit.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/UpdateMotorLimits.ui')

--- a/isstools/dialogs/UpdateSampleInfo.py
+++ b/isstools/dialogs/UpdateSampleInfo.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path_sample = pkg_resources.resource_filename('isstools', 'dialogs/UpdateSampleInfo.ui')

--- a/isstools/dialogs/UpdateScanInfo.py
+++ b/isstools/dialogs/UpdateScanInfo.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/UpdateScanInfo.ui')

--- a/isstools/dialogs/UpdateUserDialog.py
+++ b/isstools/dialogs/UpdateUserDialog.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'dialogs/UpdateUserDialog.ui')

--- a/isstools/elements/batch_elements.py
+++ b/isstools/elements/batch_elements.py
@@ -2,7 +2,7 @@ import numpy as np
 import pkg_resources
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Qt
-from qtpy.Qt import QObject
+from qtpy.QtCore import QObject
 import copy
 
 path_icon_experiment = pkg_resources.resource_filename('isstools', 'icons/experiment.png')

--- a/isstools/elements/batch_elements.py
+++ b/isstools/elements/batch_elements.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pkg_resources
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import Qt
-from PyQt5.Qt import QObject
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.Qt import QObject
 import copy
 
 path_icon_experiment = pkg_resources.resource_filename('isstools', 'icons/experiment.png')

--- a/isstools/elements/elements.py
+++ b/isstools/elements/elements.py
@@ -1,6 +1,6 @@
 import pkg_resources
 import json
-from PyQt5 import QtWidgets, QtCore, QtGui
+from qtpy import QtWidgets, QtCore, QtGui
 from isstools.dialogs.BasicDialogs import message_box, question_message_box
 import pandas as pd
 

--- a/isstools/elements/emitting_stream.py
+++ b/isstools/elements/emitting_stream.py
@@ -1,9 +1,9 @@
-from PyQt5 import QtCore, QtGui
+from qtpy import QtCore, QtGui
 import sys
 
 
 class EmittingStream(QtCore.QObject):
-    textWritten = QtCore.pyqtSignal(str)
+    textWritten = QtCore.Signal(str)
 
     # I think this code is writing a new subclass of stdout
     # (julien)

--- a/isstools/elements/parameter_handler.py
+++ b/isstools/elements/parameter_handler.py
@@ -1,6 +1,6 @@
 import inspect
 import re
-from PyQt5 import QtWidgets
+from qtpy import QtWidgets
 
 
 def create_parameter(description, annotation, units=None):

--- a/isstools/elements/roi_widget.py
+++ b/isstools/elements/roi_widget.py
@@ -1,13 +1,13 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QApplication, QWidget, QHBoxLayout,
     QSpinBox, QLabel
 )
 
-from PyQt5.QtWidgets import QWidget, QLabel, QSpinBox, QHBoxLayout
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import QTimer
+from qtpy.QtWidgets import QWidget, QLabel, QSpinBox, QHBoxLayout
+from qtpy import QtWidgets
+from qtpy.QtCore import QTimer
 
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 
 ui_path = pkg_resources.resource_filename('isstools', 'elements/roi_widget.ui')

--- a/isstools/elements/widget_motors.py
+++ b/isstools/elements/widget_motors.py
@@ -1,15 +1,15 @@
 import pkg_resources
-from PyQt5 import uic, QtWidgets
-from PyQt5.QtCore import QThread, QSettings, Qt
-from PyQt5.QtGui import QPixmap, QCursor
-from PyQt5.Qt import  QObject
+from qtpy import uic, QtWidgets
+from qtpy.QtCore import QThread, QSettings, Qt
+from qtpy.QtGui import QPixmap, QCursor
+from qtpy.Qt import  QObject
 from bluesky.callbacks import LivePlot
 from bluesky.callbacks.mpl_plotting import LiveScatter
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import numpy as np
 from functools import partial
-from PyQt5.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem, QSlider, QToolTip
+from qtpy.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem, QSlider, QToolTip
 
 # from isstools.dialogs import MoveMotorDialog
 # from isstools.dialogs.BasicDialogs import question_message_box

--- a/isstools/elements/widget_motors.py
+++ b/isstools/elements/widget_motors.py
@@ -2,7 +2,7 @@ import pkg_resources
 from qtpy import uic, QtWidgets
 from qtpy.QtCore import QThread, QSettings, Qt
 from qtpy.QtGui import QPixmap, QCursor
-from qtpy.Qt import  QObject
+from qtpy.QtCore import  QObject
 from bluesky.callbacks import LivePlot
 from bluesky.callbacks.mpl_plotting import LiveScatter
 import bluesky.plan_stubs as bps

--- a/isstools/elements/widget_spectrometer_R.py
+++ b/isstools/elements/widget_spectrometer_R.py
@@ -1,15 +1,15 @@
 import pkg_resources
-from PyQt5 import uic, QtWidgets
-from PyQt5.QtCore import QThread, QSettings, Qt
-from PyQt5.QtGui import QPixmap, QCursor
-from PyQt5.Qt import  QObject
+from qtpy import uic, QtWidgets
+from qtpy.QtCore import QThread, QSettings, Qt
+from qtpy.QtGui import QPixmap, QCursor
+from qtpy.Qt import  QObject
 from bluesky.callbacks import LivePlot
 from bluesky.callbacks.mpl_plotting import LiveScatter
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import numpy as np
 from functools import partial
-from PyQt5.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem, QSlider, QToolTip
+from qtpy.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem, QSlider, QToolTip
 from isstools.dialogs.BasicDialogs import message_box, question_message_box
 ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_spectrometer_R.ui')
 

--- a/isstools/elements/widget_spectrometer_R.py
+++ b/isstools/elements/widget_spectrometer_R.py
@@ -2,7 +2,7 @@ import pkg_resources
 from qtpy import uic, QtWidgets
 from qtpy.QtCore import QThread, QSettings, Qt
 from qtpy.QtGui import QPixmap, QCursor
-from qtpy.Qt import  QObject
+from qtpy.QtCore import  QObject
 from bluesky.callbacks import LivePlot
 from bluesky.callbacks.mpl_plotting import LiveScatter
 import bluesky.plan_stubs as bps

--- a/isstools/widgets/widget_batch.py
+++ b/isstools/widgets/widget_batch.py
@@ -1,10 +1,10 @@
 import sys
 
 import pkg_resources
-from PyQt5 import uic, QtGui, QtCore, QtWidgets
-from PyQt5.Qt import Qt
+from qtpy import uic, QtGui, QtCore, QtWidgets
+from qtpy.Qt import Qt
 
-from PyQt5.QtWidgets import QMenu
+from qtpy.QtWidgets import QMenu
 # from xas.trajectory import trajectory_manager
 # from isstools.widgets import widget_batch_manual
 
@@ -24,9 +24,9 @@ ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_batch_manual.ui')
 
 
 class UIBatch(*uic.loadUiType(ui_path)):
-    sample_list_changed_signal = QtCore.pyqtSignal()
-    scan_list_changed_signal = QtCore.pyqtSignal()
-    batch_list_changed_signal = QtCore.pyqtSignal()
+    sample_list_changed_signal = QtCore.Signal()
+    scan_list_changed_signal = QtCore.Signal()
+    batch_list_changed_signal = QtCore.Signal()
     def __init__(self,
                  service_plan_funcs=None,
                  hhm=None,

--- a/isstools/widgets/widget_batch.py
+++ b/isstools/widgets/widget_batch.py
@@ -2,7 +2,7 @@ import sys
 
 import pkg_resources
 from qtpy import uic, QtGui, QtCore, QtWidgets
-from qtpy.Qt import Qt
+from qtpy.QtCore import Qt
 
 from qtpy.QtWidgets import QMenu
 # from xas.trajectory import trajectory_manager

--- a/isstools/widgets/widget_batch_manual_legacy.py
+++ b/isstools/widgets/widget_batch_manual_legacy.py
@@ -1,6 +1,6 @@
 import pkg_resources
 from qtpy import uic, QtGui, QtCore, QtWidgets
-from qtpy.Qt import Qt
+from qtpy.QtCore import Qt
 
 from qtpy.QtWidgets import QMenu
 from isstools.elements import elements

--- a/isstools/widgets/widget_batch_manual_legacy.py
+++ b/isstools/widgets/widget_batch_manual_legacy.py
@@ -1,8 +1,8 @@
 import pkg_resources
-from PyQt5 import uic, QtGui, QtCore, QtWidgets
-from PyQt5.Qt import Qt
+from qtpy import uic, QtGui, QtCore, QtWidgets
+from qtpy.Qt import Qt
 
-from PyQt5.QtWidgets import QMenu
+from qtpy.QtWidgets import QMenu
 from isstools.elements import elements
 from isstools.elements.parameter_handler import parse_plan_parameters
 # from xas.trajectory import trajectory_manager
@@ -18,9 +18,9 @@ ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_batch_manual.ui')
 
 
 class UIBatchManual(*uic.loadUiType(ui_path)):
-    sample_list_changed_signal = QtCore.pyqtSignal()
-    scan_list_changed_signal = QtCore.pyqtSignal()
-    batch_list_changed_signal = QtCore.pyqtSignal()
+    sample_list_changed_signal = QtCore.Signal()
+    scan_list_changed_signal = QtCore.Signal()
+    batch_list_changed_signal = QtCore.Signal()
     def __init__(self,
                  service_plan_funcs,
                  hhm,

--- a/isstools/widgets/widget_beamline_setup.py
+++ b/isstools/widgets/widget_beamline_setup.py
@@ -5,8 +5,8 @@ from datetime import datetime
 import bluesky.plan_stubs as bps
 import numpy as np
 import pkg_resources
-from PyQt5 import uic, QtWidgets, QtCore
-from PyQt5.QtCore import QThread, QSettings
+from qtpy import uic, QtWidgets, QtCore
+from qtpy.QtCore import QThread, QSettings
 from bluesky.callbacks import LivePlot
 from isstools.dialogs import (UpdateHHMFeedbackSettings, MoveMotorDialog)
 from isstools.dialogs.BasicDialogs import question_message_box, error_message_box, message_box

--- a/isstools/widgets/widget_emission_energy_selector.py
+++ b/isstools/widgets/widget_emission_energy_selector.py
@@ -1,6 +1,6 @@
 import json
 import pkg_resources
-from PyQt5 import uic
+from qtpy import uic
 from isstools.elements.elements import elements_lines_dict
 from ..elements.elements import get_spectrometer_line_dict
 

--- a/isstools/widgets/widget_energy_selector.py
+++ b/isstools/widgets/widget_energy_selector.py
@@ -2,7 +2,7 @@
 import json
 
 import pkg_resources
-from PyQt5 import uic
+from qtpy import uic
 
 ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_energy_selector.ui')
 ui_path_without_e0 = pkg_resources.resource_filename('isstools', 'ui/ui_energy_selector_without_e0.ui')

--- a/isstools/widgets/widget_energy_selector_with_periodic_table.py
+++ b/isstools/widgets/widget_energy_selector_with_periodic_table.py
@@ -2,7 +2,7 @@
 import json
 
 import pkg_resources
-from PyQt5 import uic
+from qtpy import uic
 from isstools.dialogs import PeriodicTable
 
 ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_energy_selector_with_periodic_table.ui')

--- a/isstools/widgets/widget_info_beamline.py
+++ b/isstools/widgets/widget_info_beamline.py
@@ -1,5 +1,5 @@
 
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 import requests
 import urllib.request

--- a/isstools/widgets/widget_info_general.py
+++ b/isstools/widgets/widget_info_general.py
@@ -1,5 +1,5 @@
 
-from PyQt5 import uic, QtGui, QtCore
+from qtpy import uic, QtGui, QtCore
 import pkg_resources
 import requests
 import urllib.request
@@ -12,7 +12,7 @@ from timeit import default_timer as timer
 from isstools.dialogs.BasicDialogs import message_box
 from isscloudtools.initialize import get_slack_service, get_dropbox_service, get_gmail_service
 import bluesky.plan_stubs as bps
-from PyQt5 import uic, QtWidgets
+from qtpy import uic, QtWidgets
 
 from xas.file_io import make_user_dir
 from isscloudtools.slack import *

--- a/isstools/widgets/widget_info_shutters.py
+++ b/isstools/widgets/widget_info_shutters.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic, QtCore, QtWidgets
+from qtpy import uic, QtCore, QtWidgets
 import pkg_resources
 
 
@@ -6,7 +6,7 @@ ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_info_shutters.ui')
 
 
 class UIInfoShutters(*uic.loadUiType(ui_path)):
-    shutters_sig = QtCore.pyqtSignal()
+    shutters_sig = QtCore.Signal()
     def __init__(self,
                  shutters=None,
                  plan_processor=None,

--- a/isstools/widgets/widget_johann_tools.py
+++ b/isstools/widgets/widget_johann_tools.py
@@ -1,6 +1,6 @@
 import json
 import pkg_resources
-from PyQt5 import uic, QtWidgets, QtCore
+from qtpy import uic, QtWidgets, QtCore
 from isstools.widgets import widget_emission_energy_selector
 import bluesky.plan_stubs as bps
 from xas.spectrometer import Crystal

--- a/isstools/widgets/widget_motors_compact.py
+++ b/isstools/widgets/widget_motors_compact.py
@@ -1,7 +1,7 @@
 import pkg_resources
 from qtpy import uic, QtWidgets
 from qtpy.QtCore import QThread, QSettings
-from qtpy.Qt import  QObject
+from qtpy.QtCore import  QObject
 from bluesky.callbacks import LivePlot
 from bluesky.callbacks.mpl_plotting import LiveScatter
 import bluesky.plan_stubs as bps

--- a/isstools/widgets/widget_motors_compact.py
+++ b/isstools/widgets/widget_motors_compact.py
@@ -1,15 +1,15 @@
 import pkg_resources
-from PyQt5 import uic, QtWidgets
-from PyQt5.QtCore import QThread, QSettings
-from PyQt5.Qt import  QObject
+from qtpy import uic, QtWidgets
+from qtpy.QtCore import QThread, QSettings
+from qtpy.Qt import  QObject
 from bluesky.callbacks import LivePlot
 from bluesky.callbacks.mpl_plotting import LiveScatter
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import numpy as np
 from functools import partial
-from PyQt5.QtWidgets import QLabel, QPushButton, QLineEdit
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QLabel, QPushButton, QLineEdit
+from qtpy.QtCore import Qt
 
 # from isstools.dialogs import MoveMotorDialog
 # from isstools.dialogs.BasicDialogs import question_message_box

--- a/isstools/widgets/widget_pilatus.py
+++ b/isstools/widgets/widget_pilatus.py
@@ -1,9 +1,9 @@
 import pkg_resources
-from PyQt5 import uic, QtCore
+from qtpy import uic, QtCore
 from matplotlib.widgets import RectangleSelector, Cursor
-from PyQt5.Qt import QSplashScreen, QObject
-from PyQt5.QtWidgets import QToolTip
-from PyQt5.QtGui import QPixmap, QCursor
+from qtpy.Qt import QSplashScreen, QObject
+from qtpy.QtWidgets import QToolTip
+from qtpy.QtGui import QPixmap, QCursor
 from isstools.dialogs.BasicDialogs import message_box
 from isstools.elements.widget_motors import UIWidgetMotors
 from functools import partial

--- a/isstools/widgets/widget_pilatus.py
+++ b/isstools/widgets/widget_pilatus.py
@@ -1,8 +1,8 @@
 import pkg_resources
 from qtpy import uic, QtCore
 from matplotlib.widgets import RectangleSelector, Cursor
-from qtpy.Qt import QSplashScreen, QObject
-from qtpy.QtWidgets import QToolTip
+from qtpy.QtCore import QObject
+from qtpy.QtWidgets import QToolTip, QSplashScreen
 from qtpy.QtGui import QPixmap, QCursor
 from isstools.dialogs.BasicDialogs import message_box
 from isstools.elements.widget_motors import UIWidgetMotors

--- a/isstools/widgets/widget_plan_queue.py
+++ b/isstools/widgets/widget_plan_queue.py
@@ -6,9 +6,9 @@ from isstools.widgets import widget_energy_selector
 
 import numpy as np
 import pkg_resources
-from PyQt5 import uic, QtWidgets, QtCore, QtGui
-from PyQt5.Qt import Qt
-from PyQt5.QtWidgets import QMenu
+from qtpy import uic, QtWidgets, QtCore, QtGui
+from qtpy.Qt import Qt
+from qtpy.QtWidgets import QMenu
 
 from isstools.conversions import xray
 from isstools.dialogs import UpdateAngleOffset
@@ -24,7 +24,7 @@ from isstools.widgets import widget_emission_energy_selector
 ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_plan_queue_v2.ui')
 
 class UIPlanQueue(*uic.loadUiType(ui_path)):
-    # plansChanged = QtCore.pyqtSignal()
+    # plansChanged = QtCore.Signal()
 
     def __init__(self,
                  hhm= None,

--- a/isstools/widgets/widget_plan_queue.py
+++ b/isstools/widgets/widget_plan_queue.py
@@ -7,7 +7,7 @@ from isstools.widgets import widget_energy_selector
 import numpy as np
 import pkg_resources
 from qtpy import uic, QtWidgets, QtCore, QtGui
-from qtpy.Qt import Qt
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMenu
 
 from isstools.conversions import xray

--- a/isstools/widgets/widget_processing.py
+++ b/isstools/widgets/widget_processing.py
@@ -8,11 +8,11 @@ from pathlib import Path
 import pkg_resources
 import requests
 
-# PyQt5 modules
-from PyQt5 import uic, QtWidgets, QtCore
-from PyQt5.QtCore import QObject, pyqtSignal, QThread
-from PyQt5.QtWidgets import QListWidgetItem, QAbstractItemView
-from PyQt5.QtGui import QColor
+# qtpy modules
+from qtpy import uic, QtWidgets, QtCore
+from qtpy.QtCore import QObject, Signal, QThread
+from qtpy.QtWidgets import QListWidgetItem, QAbstractItemView
+from qtpy.QtGui import QColor
 
 # External packages (scientific/data handling)
 from databroker.queries import TimeRange, Key
@@ -23,8 +23,8 @@ ROOT_PATH = '/nsls2/data/iss/legacy'
 USER_PATH = 'processed'
 
 class ProposalWorker(QObject):
-    finished = pyqtSignal(list)
-    error = pyqtSignal(str)
+    finished = Signal(list)
+    error = Signal(str)
 
     def __init__(self, year, cycle):
         super().__init__()

--- a/isstools/widgets/widget_run.py
+++ b/isstools/widgets/widget_run.py
@@ -3,7 +3,7 @@ from timeit import default_timer as timer
 
 import numpy as np
 import pkg_resources
-from PyQt5 import uic, QtCore
+from qtpy import uic, QtCore
 from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar)
@@ -23,7 +23,7 @@ ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_run.ui')
 
 
 class UIRun(*uic.loadUiType(ui_path)):
-    # plansAdded = QtCore.pyqtSignal()
+    # plansAdded = QtCore.Signal()
 
     def __init__(self,
                  scan_manager = None,

--- a/isstools/widgets/widget_sample_manager.py
+++ b/isstools/widgets/widget_sample_manager.py
@@ -5,8 +5,9 @@ import pkg_resources
 import math
 
 from qtpy import uic, QtGui, QtCore, QtWidgets
+from qtpy.uic import loadUiType
 from qtpy.QtGui import QPixmap, QCursor
-from qtpy.Qt import QObject, Qt
+from qtpy.QtCore import QObject, Qt
 from qtpy.QtCore import QThread, QSettings
 from qtpy.QtWidgets import QMenu, QToolTip, QHBoxLayout, QWidget
 from isstools.elements.widget_motors import UIWidgetMotors, UIWidgetMotorsWithSlider
@@ -36,7 +37,7 @@ def print_to_gui(msg, tag='', add_timestamp=False, ntabs=0, stdout_alt=sys.stdou
     except NameError:
         stdout = stdout_alt
 
-    msg = '\t'*ntabs + msg
+    msg = '\t'*ntabs + msg/nsls2/data3/iss/shared/config/repos/isstools/isstools/widgets/widget_sample_manager.py
     if add_timestamp:
         msg = f'({time_now_str()}) {msg}'
     if tag:
@@ -99,7 +100,7 @@ sample_position_widget_dict = {
 
 
 
-class UISampleManager(*uic.loadUiType(ui_path)):
+class UISampleManager(*loadUiType(ui_path)):
     # sample_list_changed_signal = QtCore.Signal()
 
     def __init__(self,

--- a/isstools/widgets/widget_sample_manager.py
+++ b/isstools/widgets/widget_sample_manager.py
@@ -4,14 +4,14 @@ import numpy as np
 import pkg_resources
 import math
 
-from PyQt5 import uic, QtGui, QtCore, QtWidgets
-from PyQt5.QtGui import QPixmap, QCursor
-from PyQt5.Qt import QObject, Qt
-from PyQt5.QtCore import QThread, QSettings
-from PyQt5.QtWidgets import QMenu, QToolTip, QHBoxLayout, QWidget
+from qtpy import uic, QtGui, QtCore, QtWidgets
+from qtpy.QtGui import QPixmap, QCursor
+from qtpy.Qt import QObject, Qt
+from qtpy.QtCore import QThread, QSettings
+from qtpy.QtWidgets import QMenu, QToolTip, QHBoxLayout, QWidget
 from isstools.elements.widget_motors import UIWidgetMotors, UIWidgetMotorsWithSlider
 from ..elements.elements import remove_special_characters
-from PyQt5.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem
+from qtpy.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem
 import time as ttime
 from datetime import datetime
 from isstools.elements.qmicroscope import Microscope
@@ -100,7 +100,7 @@ sample_position_widget_dict = {
 
 
 class UISampleManager(*uic.loadUiType(ui_path)):
-    # sample_list_changed_signal = QtCore.pyqtSignal()
+    # sample_list_changed_signal = QtCore.Signal()
 
     def __init__(self,
                  sample_stage=None,

--- a/isstools/widgets/widget_sample_manager.py
+++ b/isstools/widgets/widget_sample_manager.py
@@ -37,7 +37,7 @@ def print_to_gui(msg, tag='', add_timestamp=False, ntabs=0, stdout_alt=sys.stdou
     except NameError:
         stdout = stdout_alt
 
-    msg = '\t'*ntabs + msg/nsls2/data3/iss/shared/config/repos/isstools/isstools/widgets/widget_sample_manager.py
+    msg = '\t'*ntabs + msg
     if add_timestamp:
         msg = f'({time_now_str()}) {msg}'
     if tag:

--- a/isstools/widgets/widget_sample_positioner.py
+++ b/isstools/widgets/widget_sample_positioner.py
@@ -1,6 +1,6 @@
 import json
 import pkg_resources
-from PyQt5 import uic, QtCore
+from qtpy import uic, QtCore
 from isstools.elements.elements import elements_lines_dict
 
 ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_sample_positioner.ui')

--- a/isstools/widgets/widget_sample_registry.py
+++ b/isstools/widgets/widget_sample_registry.py
@@ -4,7 +4,7 @@ import sys
 import pkg_resources
 import json
 from qtpy import uic, QtCore, QtWidgets, QtGui
-from qtpy.Qt import QObject
+from qtpy.QtCore import QObject
 from bluesky.plan_stubs import mv
 # from isstools.batch.table_batch import XASBatchExperiment
 # from xas.trajectory import trajectory_manager

--- a/isstools/widgets/widget_sample_registry.py
+++ b/isstools/widgets/widget_sample_registry.py
@@ -3,8 +3,8 @@ import sys
 
 import pkg_resources
 import json
-from PyQt5 import uic, QtCore, QtWidgets, QtGui
-from PyQt5.Qt import QObject
+from qtpy import uic, QtCore, QtWidgets, QtGui
+from qtpy.Qt import QObject
 from bluesky.plan_stubs import mv
 # from isstools.batch.table_batch import XASBatchExperiment
 # from xas.trajectory import trajectory_manager

--- a/isstools/widgets/widget_scan_manager.py
+++ b/isstools/widgets/widget_scan_manager.py
@@ -7,7 +7,7 @@ from isstools.widgets import widget_energy_selector
 import numpy as np
 import pkg_resources
 from qtpy import uic, QtWidgets, QtCore, QtGui
-from qtpy.Qt import Qt
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMenu
 
 from isstools.conversions import xray

--- a/isstools/widgets/widget_scan_manager.py
+++ b/isstools/widgets/widget_scan_manager.py
@@ -6,9 +6,9 @@ from isstools.widgets import widget_energy_selector
 
 import numpy as np
 import pkg_resources
-from PyQt5 import uic, QtWidgets, QtCore, QtGui
-from PyQt5.Qt import Qt
-from PyQt5.QtWidgets import QMenu
+from qtpy import uic, QtWidgets, QtCore, QtGui
+from qtpy.Qt import Qt
+from qtpy.QtWidgets import QMenu
 
 from isstools.conversions import xray
 from isstools.dialogs import UpdateAngleOffset
@@ -25,7 +25,7 @@ from isstools.widgets import widget_emission_energy_selector
 ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_scan_manager.ui')
 
 class UIScanManager(*uic.loadUiType(ui_path)):
-    scansChanged = QtCore.pyqtSignal()
+    scansChanged = QtCore.Signal()
 
     def __init__(self,
                  hhm= None,

--- a/isstools/widgets/widget_sdd_manager.py
+++ b/isstools/widgets/widget_sdd_manager.py
@@ -11,7 +11,8 @@ from matplotlib.backends.backend_qt5agg import (
     NavigationToolbar2QT as NavigationToolbar)
 from matplotlib.figure import Figure
 from matplotlib.widgets import Cursor
-from qtpy.Qt import QSplashScreen, QObject
+from qtpy.QtCore import QObject
+from qtpy.QtWidgets import QSplashScreen
 import numpy
 
 from isstools.dialogs.BasicDialogs import question_message_box, error_message_box, message_box

--- a/isstools/widgets/widget_sdd_manager.py
+++ b/isstools/widgets/widget_sdd_manager.py
@@ -5,13 +5,13 @@ import bluesky.plan_stubs as bps
 import numpy as np
 import pkg_resources
 
-from PyQt5 import uic,  QtCore
+from qtpy import uic,  QtCore
 from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar)
 from matplotlib.figure import Figure
 from matplotlib.widgets import Cursor
-from PyQt5.Qt import QSplashScreen, QObject
+from qtpy.Qt import QSplashScreen, QObject
 import numpy
 
 from isstools.dialogs.BasicDialogs import question_message_box, error_message_box, message_box

--- a/isstools/widgets/widget_spectrometer.py
+++ b/isstools/widgets/widget_spectrometer.py
@@ -1,17 +1,17 @@
 import pkg_resources
-from PyQt5 import uic, QtWidgets
-from PyQt5.QtCore import QThread, QSettings
-from PyQt5.Qt import QObject
+from qtpy import uic, QtWidgets
+from qtpy.QtCore import QThread, QSettings
+from qtpy.Qt import QObject
 from bluesky.callbacks import LivePlot
 from bluesky.callbacks.mpl_plotting import LiveScatter
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import numpy as np
 import pandas as pd
-from PyQt5 import uic, QtGui, QtCore, QtWidgets
+from qtpy import uic, QtGui, QtCore, QtWidgets
 from datetime import datetime
 import time as ttime
-from PyQt5.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem, QSlider, QToolTip, QCheckBox
+from qtpy.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem, QSlider, QToolTip, QCheckBox
 import xraydb
 import copy
 from isstools.dialogs import MoveMotorDialog
@@ -33,8 +33,8 @@ ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_spectrometer.ui')
 
 
 class UISpectrometer(*uic.loadUiType(ui_path)):
-    spectrometer_config_list_changed_signal = QtCore.pyqtSignal()
-    spectrometer_config_changed_signal = QtCore.pyqtSignal()
+    spectrometer_config_list_changed_signal = QtCore.Signal()
+    spectrometer_config_changed_signal = QtCore.Signal()
 
     def __init__(self,
                  RE,

--- a/isstools/widgets/widget_spectrometer.py
+++ b/isstools/widgets/widget_spectrometer.py
@@ -1,7 +1,7 @@
 import pkg_resources
 from qtpy import uic, QtWidgets
 from qtpy.QtCore import QThread, QSettings
-from qtpy.Qt import QObject
+from qtpy.QtCore import QObject
 from bluesky.callbacks import LivePlot
 from bluesky.callbacks.mpl_plotting import LiveScatter
 import bluesky.plan_stubs as bps

--- a/isstools/widgets/widget_spectrometer_motors.py
+++ b/isstools/widgets/widget_spectrometer_motors.py
@@ -1,6 +1,6 @@
 import pkg_resources
-from PyQt5 import uic, QtCore
-from PyQt5.QtGui import QPixmap
+from qtpy import uic, QtCore
+from qtpy.QtGui import QPixmap
 from isstools.elements.widget_motors import UIWidgetMotors
 from isstools.elements.widget_spectrometer_R import UIWidgetSpectrometerR
 from isstools.dialogs.BasicDialogs import message_box, question_message_box

--- a/isstools/widgets/widget_user_manager.py
+++ b/isstools/widgets/widget_user_manager.py
@@ -8,18 +8,18 @@ import time as ttime
 import uuid
 
 
-from PyQt5 import uic, QtGui, QtCore, QtWidgets
-from PyQt5.QtGui import QPixmap, QCursor, QStandardItem
-from PyQt5.Qt import QObject, Qt
-from PyQt5.QtCore import QThread, QSettings
-from PyQt5.QtWidgets import QMenu, QToolTip, QHBoxLayout, QWidget, QListWidgetItem
+from qtpy import uic, QtGui, QtCore, QtWidgets
+from qtpy.QtGui import QPixmap, QCursor, QStandardItem
+from qtpy.Qt import QObject, Qt
+from qtpy.QtCore import QThread, QSettings
+from qtpy.QtWidgets import QMenu, QToolTip, QHBoxLayout, QWidget, QListWidgetItem
 from isstools.elements.widget_motors import UIWidgetMotors, UIWidgetMotorsWithSlider
 from ..elements.elements import remove_special_characters
 
 
 
 from isstools.dialogs import UpdateUserDialog, SetEnergy, GetEmailAddress
-from PyQt5 import uic, QtWidgets
+from qtpy import uic, QtWidgets
 
 from xas.file_io import make_user_dir
 from isscloudtools.slack import *
@@ -27,7 +27,7 @@ from isscloudtools.gmail import *
 from isscloudtools.dropbox import *
 
 
-from PyQt5.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem
+from qtpy.QtWidgets import QLabel, QPushButton, QLineEdit, QSizePolicy, QSpacerItem
 from isstools.dialogs.BasicDialogs import question_message_box, error_message_box, message_box
 
 from isstools.dialogs.BasicDialogs import message_box, question_message_box
@@ -42,7 +42,7 @@ USER_PATH = 'processed'
 
 class UIUserManager(*uic.loadUiType(ui_path)):
 
-    sample_list_changed_signal = QtCore.pyqtSignal()
+    sample_list_changed_signal = QtCore.Signal()
 
     def __init__(self,
                  RE=None,

--- a/isstools/widgets/widget_user_manager.py
+++ b/isstools/widgets/widget_user_manager.py
@@ -10,7 +10,7 @@ import uuid
 
 from qtpy import uic, QtGui, QtCore, QtWidgets
 from qtpy.QtGui import QPixmap, QCursor, QStandardItem
-from qtpy.Qt import QObject, Qt
+from qtpy.QtCore import QObject, Qt
 from qtpy.QtCore import QThread, QSettings
 from qtpy.QtWidgets import QMenu, QToolTip, QHBoxLayout, QWidget, QListWidgetItem
 from isstools.elements.widget_motors import UIWidgetMotors, UIWidgetMotorsWithSlider

--- a/isstools/widgets/widget_xia_manager.py
+++ b/isstools/widgets/widget_xia_manager.py
@@ -5,18 +5,18 @@ import bluesky.plan_stubs as bps
 import numpy as np
 import pkg_resources
 
-from PyQt5 import uic,  QtCore
+from qtpy import uic,  QtCore
 from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar)
 from matplotlib.figure import Figure
 from matplotlib.widgets import Cursor
-from PyQt5.Qt import QSplashScreen, QObject
+from qtpy.Qt import QSplashScreen, QObject
 import numpy
-from PyQt5 import  QtWidgets
+from qtpy import  QtWidgets
 from scipy.optimize import curve_fit
 import matplotlib.pyplot as plt
-from PyQt5.QtCore import pyqtSignal
+from qtpy.QtCore import Signal
 
 from isstools.dialogs.BasicDialogs import question_message_box, error_message_box, message_box
 from isstools.elements.figure_update import update_figure, setup_figure
@@ -29,7 +29,7 @@ ui_path = pkg_resources.resource_filename('isstools', 'ui/ui_xia_manager.ui')
 
 
 class UIXIAManager(*uic.loadUiType(ui_path)):
-    element_selected = pyqtSignal(str)  # Signal to send selected element
+    element_selected = Signal(str)  # Signal to send selected element
     def __init__(self,
                  service_plan_funcs=None,
                  ge_detector = None,

--- a/isstools/widgets/widget_xia_manager.py
+++ b/isstools/widgets/widget_xia_manager.py
@@ -11,7 +11,9 @@ from matplotlib.backends.backend_qt5agg import (
     NavigationToolbar2QT as NavigationToolbar)
 from matplotlib.figure import Figure
 from matplotlib.widgets import Cursor
-from qtpy.Qt import QSplashScreen, QObject
+from qtpy.QtCore import QObject
+from qtpy.QtWidgets import QSplashScreen
+
 import numpy
 from qtpy import  QtWidgets
 from scipy.optimize import curve_fit

--- a/isstools/xasproject/pilatus_gui.py
+++ b/isstools/xasproject/pilatus_gui.py
@@ -1,10 +1,10 @@
 import pkg_resources
-from PyQt5 import uic, QtCore
+from qtpy import uic, QtCore
 
 from matplotlib.widgets import RectangleSelector, Cursor
-from PyQt5.Qt import QSplashScreen, QObject
-from PyQt5.QtWidgets import QToolTip, QApplication
-from PyQt5.QtGui import QPixmap, QCursor
+from qtpy.Qt import QSplashScreen, QObject
+from qtpy.QtWidgets import QToolTip, QApplication
+from qtpy.QtGui import QPixmap, QCursor
 from isstools.dialogs.BasicDialogs import message_box
 # from isstools.elements.widget_motors import UIWidgetMotors
 from functools import partial

--- a/isstools/xasproject/pilatus_gui.py
+++ b/isstools/xasproject/pilatus_gui.py
@@ -2,7 +2,8 @@ import pkg_resources
 from qtpy import uic, QtCore
 
 from matplotlib.widgets import RectangleSelector, Cursor
-from qtpy.Qt import QSplashScreen, QObject
+from qtpy.QtCore import QObject
+from qtpy.QtWidgets import QSplashScreen
 from qtpy.QtWidgets import QToolTip, QApplication
 from qtpy.QtGui import QPixmap, QCursor
 from isstools.dialogs.BasicDialogs import message_box

--- a/isstools/xasproject/scratch_pilatus.py
+++ b/isstools/xasproject/scratch_pilatus.py
@@ -1,9 +1,9 @@
 import pkg_resources
-from PyQt5 import uic, QtCore
+from qtpy import uic, QtCore
 from matplotlib.widgets import RectangleSelector, Cursor
-from PyQt5.Qt import QSplashScreen, QObject
-from PyQt5.QtWidgets import QToolTip
-from PyQt5.QtGui import QPixmap, QCursor
+from qtpy.Qt import QSplashScreen, QObject
+from qtpy.QtWidgets import QToolTip
+from qtpy.QtGui import QPixmap, QCursor
 from isstools.dialogs.BasicDialogs import message_box
 from isstools.elements.widget_motors import UIWidgetMotors
 from functools import partial

--- a/isstools/xasproject/scratch_pilatus.py
+++ b/isstools/xasproject/scratch_pilatus.py
@@ -1,7 +1,8 @@
 import pkg_resources
 from qtpy import uic, QtCore
 from matplotlib.widgets import RectangleSelector, Cursor
-from qtpy.Qt import QSplashScreen, QObject
+from qtpy.QtCore import QObject
+from qtpy.QtWidgets import QSplashScreen
 from qtpy.QtWidgets import QToolTip
 from qtpy.QtGui import QPixmap, QCursor
 from isstools.dialogs.BasicDialogs import message_box

--- a/isstools/xlive.py
+++ b/isstools/xlive.py
@@ -4,10 +4,10 @@ import numpy as np
 import pkg_resources
 import math
 
-from PyQt5 import uic, QtGui, QtCore, QtWidgets
-from PyQt5.QtCore import pyqtSignal, QObject, QThread
+from qtpy import uic, QtGui, QtCore, QtWidgets
+from qtpy.QtCore import Signal, QObject, QThread
 
-from PyQt5.QtCore import QThread, QSettings
+from qtpy.QtCore import QThread, QSettings
 
 from .widgets import (widget_info_general,
                       widget_scan_manager,
@@ -34,7 +34,7 @@ from isscloudtools.gmail import create_html_message, upload_draft, send_draft
 import time as ttime
 from xas.process import process_interpolate_bin
 from isstools.dialogs.BasicDialogs import question_message_box, error_message_box, message_box
-from PyQt5.QtCore import QThread, pyqtSignal
+from qtpy.QtCore import QThread, Signal
 from queue import Queue, Empty
 import time as ttime
 import traceback
@@ -57,9 +57,9 @@ def auto_redraw_factory(fnc):
 
 
 class XliveGui(*uic.loadUiType(ui_path)):
-    plans_changed_signal = QtCore.pyqtSignal()
-    plan_processor_status_changed_signal = QtCore.pyqtSignal()
-    progress_sig = QtCore.pyqtSignal()
+    plans_changed_signal = QtCore.Signal()
+    plan_processor_status_changed_signal = QtCore.Signal()
+    progress_sig = QtCore.Signal()
 
     def __init__(self,
                  data_collection_plan_funcs=None,
@@ -639,8 +639,8 @@ class XliveGui(*uic.loadUiType(ui_path)):
 
 class ProcessingThread(QThread):
 
-    processing_event = pyqtSignal(str, str, int)  # event_type, uid_or_msg, queue_size
-    processing_error = pyqtSignal(str)
+    processing_event = Signal(str, str, int)  # event_type, uid_or_msg, queue_size
+    processing_error = Signal(str)
 
     def __init__(self, gui, print_func=None, processing_ioc_uid=None):
         super().__init__()


### PR DESCRIPTION
This will enable the use of all backends:
- `pyqt5`
- `pyqt6`
- `pyside2`
- `pyside6`

We need to resolve the issue observed with the `qtpy` + `pyside6` when it was attempted to read the QtDesigner-created `*.ui` files (to be addressed as in a separate PR).