### PR TITLE
Add qtpy+PySide6 UI compatibility test; fix duplicate widget names

### DIFF
--- a/isstools/ui/test_ui_compat.py
+++ b/isstools/ui/test_ui_compat.py
@@ -1,0 +1,43 @@
+"""Test that every .ui file in this directory loads successfully with qtpy + PySide6.
+
+Run with:
+    pixi run python isstools/ui/test_ui_compat.py
+
+The script must be executed through ``pixi run`` so that ``pyside6-uic`` (used
+internally by ``qtpy.uic.loadUiType``) is available on PATH.
+"""
+
+import glob
+import os
+import sys
+
+# Must be set before any Qt import.
+os.environ.setdefault("QT_API", "pyside6")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from qtpy import uic  # noqa: E402  (import after env-var setup)
+from qtpy.QtWidgets import QApplication  # noqa: E402
+
+app = QApplication.instance() or QApplication(sys.argv)
+
+ui_dir = os.path.dirname(os.path.abspath(__file__))
+ui_files = sorted(glob.glob(os.path.join(ui_dir, "*.ui")))
+
+passed = []
+failed = []
+
+for ui_file in ui_files:
+    name = os.path.basename(ui_file)
+    try:
+        cls, base = uic.loadUiType(ui_file)
+        print(f"OK    {name}")
+        passed.append(name)
+    except Exception as exc:
+        print(f"FAIL  {name}: {exc}")
+        failed.append((name, exc))
+
+print()
+print(f"Results: {len(passed)} passed, {len(failed)} failed out of {len(ui_files)} files.")
+
+if failed:
+    sys.exit(1)

--- a/isstools/ui/ui_sample_manager.ui
+++ b/isstools/ui/ui_sample_manager.ui
@@ -1716,7 +1716,7 @@
         </widget>
        </item>
        <item row="6" column="0" rowspan="2">
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="groupBox_2">
          <property name="minimumSize">
           <size>
            <width>100</width>

--- a/isstools/ui/ui_xlive.ui
+++ b/isstools/ui/ui_xlive.ui
@@ -227,7 +227,7 @@
      <attribute name="title">
       <string>Re-processing</string>
      </attribute>
-     <widget class="QWidget" name="horizontalLayoutWidget_7">
+     <widget class="QWidget" name="horizontalLayoutWidget_7b">
       <property name="geometry">
        <rect>
         <x>0</x>
@@ -359,7 +359,7 @@
     </property>
     <layout class="QHBoxLayout" name="layout_info_shutters"/>
    </widget>
-   <widget class="QWidget" name="horizontalLayoutWidget_11">
+   <widget class="QWidget" name="horizontalLayoutWidget_11b">
     <property name="geometry">
      <rect>
       <x>360</x>


### PR DESCRIPTION
That's something copilot came up with. Need to test at the beamline.

---

- Add isstools/ui/test_ui_compat.py: headless offscreen script that loads every .ui file with qtpy.uic.loadUiType (PySide6 backend) and reports pass/fail. Must be run via 'pixi run python isstools/ui/test_ui_compat.py' so pyside6-uic is on PATH.

- Fix ui_xlive.ui: rename second 'horizontalLayoutWidget_7' → 'horizontalLayoutWidget_7b' and second 'horizontalLayoutWidget_11' → 'horizontalLayoutWidget_11b'. pyside6-uic (Qt6) rejects duplicate object names; PyQt5 uic was lenient.

- Fix ui_sample_manager.ui: rename second 'groupBox' → 'groupBox_2' for the same reason.

All 34 .ui files now load cleanly: 34 passed, 0 failed.